### PR TITLE
docs: add usage details of custom formatter in logrus

### DIFF
--- a/log/logrus.go
+++ b/log/logrus.go
@@ -63,6 +63,14 @@ func LogrusWithWriter(writer io.Writer) Option {
 	}
 }
 
+// LogrusWithFormatter can be used to change default formatting
+// by implementing logrus.Formatter
+// For example:
+//   type PlainFormatter struct{}
+//   func (p *PlainFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+//       return []byte(entry.Message), nil
+//   }
+//   l := log.NewLogrus(log.LogrusWithFormatter(&PlainFormatter{}))
 func LogrusWithFormatter(f logrus.Formatter) Option {
 	return func(logger interface{}) {
 		logger.(*Logrus).log.SetFormatter(f)


### PR DESCRIPTION
### Description
Added the custom formatter usage details in logrus .
It is used to change default formatting provided by logrus such as `JSONFormatter` or `TextFormatter` .