### PR TITLE
refactor: remove default path in config

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -35,8 +35,11 @@ type NewRelicConfig struct {
 func main() {
 	var c Config
 	l := config.NewLoader(
-		// config.WithConfigName("config"),
-		// config.WithConfigPath("$HOME/.test"),
+		// config.WithViper(viper.New()), // default
+		// config.WithConfigName("config"), // default
+		// config.WithConfigType("yaml"), // default
+		// config.WithEnvKeyReplacer(".", "_"), // default
+		config.WithConfigPath("$HOME/.test"),
 		config.WithEnvPrefix("CONFIG"),
 	)
 
@@ -74,7 +77,7 @@ export CONFIG_NEW_RELIC_LICENSE=____LICENSE_STRING_OF_40_CHARACTERS_____
 export CONFIG_LOG_LEVEL=debug
 ```
 
-or a mix of both. 
+or a mix of both.
 
 **Configs set in environment will override the ones set as default and in yaml file.**
 

--- a/config/README.md
+++ b/config/README.md
@@ -36,10 +36,10 @@ func main() {
 	var c Config
 	l := config.NewLoader(
 		// config.WithViper(viper.New()), // default
-		// config.WithConfigName("config"), // default
-		// config.WithConfigType("yaml"), // default
+		// config.WithName("config"), // default
+		// config.WithType("yaml"), // default
 		// config.WithEnvKeyReplacer(".", "_"), // default
-		config.WithConfigPath("$HOME/.test"),
+		config.WithPath("$HOME/.test"),
 		config.WithEnvPrefix("CONFIG"),
 	)
 

--- a/config/config.go
+++ b/config/config.go
@@ -132,7 +132,6 @@ func verifyParamIsPtrToStructElsePanic(param interface{}) error {
 func getViperWithDefaults() *viper.Viper {
 	v := viper.New()
 	v.SetConfigName("config")
-	v.AddConfigPath("./")
 	v.SetConfigType("yaml")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	return v

--- a/config/config.go
+++ b/config/config.go
@@ -25,26 +25,26 @@ func WithViper(in *viper.Viper) LoaderOption {
 	}
 }
 
-// WithConfigName sets the file name of the config file without
+// WithName sets the file name of the config file without
 // the extension
-func WithConfigName(in string) LoaderOption {
+func WithName(in string) LoaderOption {
 	return func(l *Loader) {
 		l.v.SetConfigName(in)
 	}
 }
 
-// WithConfigPath adds config path to search the config file in,
+// WithPath adds config path to search the config file in,
 // can be used multiple times to add multiple paths to search
-func WithConfigPath(in string) LoaderOption {
+func WithPath(in string) LoaderOption {
 	return func(l *Loader) {
 		l.v.AddConfigPath(in)
 	}
 }
 
-// WithConfigType sets the type of the configuration e.g. "json",
+// WithType sets the type of the configuration e.g. "json",
 // "yaml", "hcl"
 // Also used for the extension of the file
-func WithConfigType(in string) LoaderOption {
+func WithType(in string) LoaderOption {
 	return func(l *Loader) {
 		l.v.SetConfigType(in)
 	}


### PR DESCRIPTION
Resolves #6.

Removed default path in `config.getViperWithDefaults()`, due to the side effects mentioned in the issue above.

Signed-off-by: burntcarrot <aadhav.n1@gmail.com>