### PR TITLE
feat(log): add feature to expose internal logrus logger

### DIFF
--- a/log/logrus.go
+++ b/log/logrus.go
@@ -10,6 +10,10 @@ type Logrus struct {
 	log *logrus.Logger
 }
 
+func (l *Logrus) GetLogrusLogger() *logrus.Logger {
+	return l.log
+}
+
 func (l Logrus) getFields(args ...interface{}) map[string]interface{} {
 	fieldMap := map[string]interface{}{}
 	if len(args) > 1 && len(args)%2 == 0 {

--- a/log/logrus_test.go
+++ b/log/logrus_test.go
@@ -75,3 +75,10 @@ func TestLogrus(t *testing.T) {
 		assert.Equal(t, "level=error msg=\"request failed\"\n", b.String())
 	})
 }
+
+func TestLogrusGetLogrusLogger(t *testing.T) {
+	t.Run("should return underlying *logrus.Logger", func(t *testing.T) {
+		logrusLogger := log.NewLogrus()
+		assert.NotNil(t, logrusLogger)
+	})
+}


### PR DESCRIPTION
Related to 
https://github.com/odpf/compass/issues/142

This PR will create a method `log.Logrus.GetLogrusLogger()` to return underlying `*logrus.Logger`.