### PR TITLE
feat: remove cmux and use http2 to mux grpc & http

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.buf.build/odpf/gw/odpf/proton v1.1.9
 	go.uber.org/zap v1.19.0
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.45.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/mux/_example/main.go
+++ b/mux/_example/main.go
@@ -4,23 +4,27 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"os/signal"
+	"syscall"
 	"time"
 
 	commonv1 "go.buf.build/odpf/gw/odpf/proton/odpf/common/v1"
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+
 	"github.com/odpf/salt/common"
 	"github.com/odpf/salt/mux"
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
 
 	grpcServer := grpc.NewServer()
 	grpcGateway := runtime.NewServeMux()
 
-	commonSvc := common.New(nil)
+	commonSvc := common.New(&commonv1.Version{})
 	grpcServer.RegisterService(&commonv1.CommonService_ServiceDesc, commonSvc)
 	if err := commonv1.RegisterCommonServiceHandlerServer(ctx, grpcGateway, commonSvc); err != nil {
 		panic(err)
@@ -28,9 +32,15 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/api/", http.StripPrefix("/api", grpcGateway))
+	httpMux.Handle("/ping", http.HandlerFunc(func(wr http.ResponseWriter, req *http.Request) {
+		for i := 0; i < 5; i++ {
+			log.Printf("dooing stuff")
+			time.Sleep(1 * time.Second)
+		}
+	}))
 
 	log.Fatalf("server exited: %v", mux.Serve(ctx, "localhost:8080",
-		mux.WithHTTP(&http.Server{Handler: httpMux}),
+		mux.WithHTTP(httpMux),
 		mux.WithGRPC(grpcServer),
 		mux.WithGracePeriod(5*time.Second),
 	))

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -3,104 +3,90 @@ package mux
 import (
 	"context"
 	"errors"
-	"net"
+	"log"
 	"net/http"
+	"strings"
 	"time"
 
-	"github.com/soheilhy/cmux"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 )
 
-const defaultGracePeriod = 5 * time.Second
+const (
+	defaultGracePeriod = 10 * time.Second
+	grpcRequestMarker  = "application/grpc"
+)
 
-// Serve starts a TCP listener and serves the registered protocol
-// servers (i.e., http, grpc, etc.) and blocks until server exits.
-// Context can be cancelled to perform graceful shutdown.
-// Use WithHTTP() and WithGRPC() to register procol servers.
+// Serve starts a TCP listener and serves the registered protocol servers and blocks
+// until server exits. Context can be cancelled to perform graceful shutdown.
+// Use WithHTTP() and WithGRPC() to register protocol servers.
 func Serve(ctx context.Context, listenAddr string, opts ...Option) error {
-	var mux cmuxWrapper
+	var mux muxServer
 	for _, opt := range opts {
 		if err := opt(&mux); err != nil {
 			return err
 		}
 	}
-	if mux.httpServer == nil && mux.grpcServer == nil {
+	if mux.httpHandler == nil && mux.grpcServer == nil {
 		return errors.New("at-least one of http & grpc server must be set")
 	}
-
 	return mux.Serve(ctx, listenAddr)
 }
 
-type cmuxWrapper struct {
-	httpServer  *http.Server
+type muxServer struct {
+	httpHandler http.Handler
 	grpcServer  *grpc.Server
 	gracePeriod time.Duration
 }
 
-func (cmw *cmuxWrapper) Serve(baseCtx context.Context, addr string) error {
+func (pmux *muxServer) Serve(baseCtx context.Context, addr string) error {
 	ctx, cancel := context.WithCancel(baseCtx)
 	defer cancel()
 
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
-	}
-	defer l.Close()
-
-	m := cmux.New(l)
-	defer m.Close()
-
-	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
-	httpL := m.Match(cmux.Any())
-
-	errorCh := make(chan error, 3)
-	serveOnListener(httpL, cmw.httpServer, errorCh)
-	serveOnListener(grpcL, cmw.grpcServer, errorCh)
-
-	go func() {
-		if err := m.Serve(); err != nil {
-			errorCh <- err
-		}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return cmw.shutDown()
-
-	case e := <-errorCh:
-		_ = cmw.shutDown()
-		return e
-	}
-}
-
-func (cmw *cmuxWrapper) shutDown() error {
-	if cmw.grpcServer != nil {
-		cmw.grpcServer.GracefulStop()
-	}
-
-	if cmw.httpServer != nil {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), cmw.gracePeriod)
-		defer cancel()
-
-		return cmw.httpServer.Shutdown(shutdownCtx)
-	}
-
-	return nil
-}
-
-func serveOnListener(l net.Listener, server interface{ Serve(l net.Listener) error }, errCh chan<- error) {
-	if server == nil {
-		return
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: h2c.NewHandler(pmux.muxedHandler(), &http2.Server{}),
 	}
 
 	go func() {
-		err := server.Serve(l)
-		if err != nil {
-			if errors.Is(err, http.ErrServerClosed) || errors.Is(err, grpc.ErrServerStopped) {
-				return
-			}
-			errCh <- err
-			return
+		err := httpServer.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("[ERROR] server exited with error: %v", err)
+
+			// force-cancel the context so that graceful shutdown sequence exits as well.
+			cancel()
 		}
 	}()
+
+	<-ctx.Done()
+
+	// context has been cancelled (due to cancelled base-context or due to
+	// server exit).
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), pmux.gracePeriod)
+	defer cancel()
+
+	err := httpServer.Shutdown(shutdownCtx)
+
+	if pmux.grpcServer != nil {
+		pmux.grpcServer.GracefulStop()
+	}
+	return err
+}
+
+func (pmux *muxServer) muxedHandler() http.Handler {
+	// if only one of gRPC and HTTP are set, no need to multiplex.
+	if pmux.grpcServer == nil {
+		return pmux.httpHandler
+	} else if pmux.httpHandler == nil {
+		return pmux.grpcServer
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), grpcRequestMarker) {
+			pmux.grpcServer.ServeHTTP(w, r)
+		} else {
+			pmux.httpHandler.ServeHTTP(w, r)
+		}
+	})
 }

--- a/mux/option.go
+++ b/mux/option.go
@@ -8,22 +8,19 @@ import (
 )
 
 // Option values can be used with Serve() for customisation.
-type Option func(m *cmuxWrapper) error
+type Option func(m *muxServer) error
 
 // WithHTTP registers the http-server for use in Serve().
-func WithHTTP(server *http.Server) Option {
-	return func(m *cmuxWrapper) error {
-		if server == nil {
-			server = &http.Server{}
-		}
-		m.httpServer = server
+func WithHTTP(h http.Handler) Option {
+	return func(m *muxServer) error {
+		m.httpHandler = h
 		return nil
 	}
 }
 
 // WithGRPC registers the gRPC-server for use in Serve().
 func WithGRPC(server *grpc.Server) Option {
-	return func(m *cmuxWrapper) error {
+	return func(m *muxServer) error {
 		if server == nil {
 			server = grpc.NewServer()
 		}
@@ -34,8 +31,8 @@ func WithGRPC(server *grpc.Server) Option {
 
 // WithGracePeriod sets the wait duration for graceful shutdown.
 func WithGracePeriod(d time.Duration) Option {
-	return func(m *cmuxWrapper) error {
-		if d == 0 {
+	return func(m *muxServer) error {
+		if d <= 0 {
 			d = defaultGracePeriod
 		}
 		m.gracePeriod = d


### PR DESCRIPTION
Removes dependency on `cmux` and uses `http2` package to multiplex both gRPC and HTTP on a single `net.Conn`..

Tested the following scenario: 

1. Expose an endpoint that is long running (for loop of 10 iterations with 1 sec interval).
2. Send one request to this endpoint (it would take 10 sec to get response)
3. Hit `ctrl+c` to initiate graceful shutdown -- this should not exit the server immediately (since a request is ongoing)
4. Try to send a new request now -- this should be rejected (server should only be waiting for draining existing and not accept any new requests)
5. Once ongoing requests finish, server process should die.