### PR TITLE
fix: zap contextual logging naming

### DIFF
--- a/log/zap.go
+++ b/log/zap.go
@@ -65,17 +65,17 @@ func (z Zap) NewContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, loggerCtxKey, z)
 }
 
-// WithFields will add Zap Fields to logger in Context
-func WithFields(ctx context.Context, fields ...zap.Field) context.Context {
+// ZapContextWithFields will add Zap Fields to logger in Context
+func ZapContextWithFields(ctx context.Context, fields ...zap.Field) context.Context {
 	return context.WithValue(ctx, loggerCtxKey, Zap{
 		// Error when not Desugaring when adding fields: github.com/ipfs/go-log/issues/85
-		log:  FromContext(ctx).GetInternalZapLogger().Desugar().With(fields...).Sugar(),
-		conf: FromContext(ctx).conf,
+		log:  ZapFromContext(ctx).GetInternalZapLogger().Desugar().With(fields...).Sugar(),
+		conf: ZapFromContext(ctx).conf,
 	})
 }
 
-// FromContext will help in fetching back zap logger from context
-func FromContext(ctx context.Context) Zap {
+// ZapFromContext will help in fetching back zap logger from context
+func ZapFromContext(ctx context.Context) Zap {
 	if ctxLogger, ok := ctx.Value(loggerCtxKey).(Zap); ok {
 		return ctxLogger
 	}

--- a/log/zap_test.go
+++ b/log/zap_test.go
@@ -77,7 +77,7 @@ func TestZap(t *testing.T) {
 
 		zapper := log.NewZap(buildBufferedZapOption(bWriter, mockedTime, randomString(10)))
 		ctx := zapper.NewContext(context.Background())
-		contextualLog := log.FromContext(ctx)
+		contextualLog := log.ZapFromContext(ctx)
 		contextualLog.Info("hello", "wor", "ld")
 		bWriter.Flush()
 
@@ -90,9 +90,9 @@ func TestZap(t *testing.T) {
 
 		zapper := log.NewZap(buildBufferedZapOption(bWriter, mockedTime, randomString(10)))
 		ctx := zapper.NewContext(context.Background())
-		ctx = log.WithFields(ctx, zap.Int("one", 1))
-		ctx = log.WithFields(ctx, zap.String("two", "two"))
-		log.FromContext(ctx).Info("hello", "wor", "ld")
+		ctx = log.ZapContextWithFields(ctx, zap.Int("one", 1))
+		ctx = log.ZapContextWithFields(ctx, zap.String("two", "two"))
+		log.ZapFromContext(ctx).Info("hello", "wor", "ld")
 		bWriter.Flush()
 
 		assert.Equal(t, mockedTime.Format("2006-01-02T15:04:05.000Z0700")+"\tINFO\thello\t{\"one\": 1, \"two\": \"two\", \"wor\": \"ld\"}\n", b.String())


### PR DESCRIPTION
resolves #52 