### PR TITLE
feat: add context-cancel support in callback-wait

### DIFF
--- a/oidc/source_oidc.go
+++ b/oidc/source_oidc.go
@@ -57,7 +57,7 @@ func (source *authHandlerSource) Token() (*oauth2.Token, error) {
 		oauth2.SetAuthURLParam(codeChallengeMethodKey, challengeMethod),
 	)
 
-	code, receivedState, err := browserAuthzHandler(source.config.RedirectURL, url)
+	code, receivedState, err := browserAuthzHandler(source.ctx, source.config.RedirectURL, url)
 	if err != nil {
 		return nil, err
 	} else if receivedState != actualState {


### PR DESCRIPTION
When the OIDC token-source is waiting for browser redirection to `redirect_url` from the authorization-server, there was no way to cancel and it would hang until a redirection callback is received. 

With this change, context cancellation will stop the `waitForCallback` and gracefully returns.