### PR TITLE
feat!: support serving multiple servers on separate ports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/muesli/termenv v0.9.0
+	github.com/oklog/run v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/pkg/errors v0.9.1
@@ -39,7 +40,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	go.buf.build/odpf/gw/odpf/proton v1.1.9
 	go.uber.org/zap v1.19.0
-	golang.org/x/net v0.0.0-20220919232410-f2f64ebce3c1
+	golang.org/x/net v0.0.0-20220919232410-f2f64ebce3c1 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 	golang.org/x/text v0.3.7
 	google.golang.org/api v0.84.0

--- a/go.sum
+++ b/go.sum
@@ -988,6 +988,8 @@ github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/mux/README.md
+++ b/mux/README.md
@@ -1,6 +1,7 @@
 # Mux
 
-`mux` package provides protocol multiplexing for HTTP & gRPC servers.
+`mux` package provides helpers for starting multiple servers. HTTP and gRPC
+servers are supported currently.
 
 ## Usage
 

--- a/mux/option.go
+++ b/mux/option.go
@@ -10,21 +10,20 @@ import (
 // Option values can be used with Serve() for customisation.
 type Option func(m *muxServer) error
 
-// WithHTTP registers the http-server for use in Serve().
-func WithHTTP(h http.Handler) Option {
+func WithHTTPTarget(addr string, srv *http.Server) Option {
+	srv.Addr = addr
 	return func(m *muxServer) error {
-		m.httpHandler = h
+		m.targets = append(m.targets, httpServeTarget{Server: srv})
 		return nil
 	}
 }
 
-// WithGRPC registers the gRPC-server for use in Serve().
-func WithGRPC(server *grpc.Server) Option {
+func WithGRPCTarget(addr string, srv *grpc.Server) Option {
 	return func(m *muxServer) error {
-		if server == nil {
-			server = grpc.NewServer()
-		}
-		m.grpcServer = server
+		m.targets = append(m.targets, gRPCServeTarget{
+			Addr:   addr,
+			Server: srv,
+		})
 		return nil
 	}
 }

--- a/mux/serve_target.go
+++ b/mux/serve_target.go
@@ -1,0 +1,55 @@
+package mux
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+
+	"google.golang.org/grpc"
+)
+
+type serveTarget interface {
+	Address() string
+	Serve(l net.Listener) error
+	Shutdown(ctx context.Context) error
+}
+
+type httpServeTarget struct {
+	*http.Server
+}
+
+func (h httpServeTarget) Address() string { return h.Addr }
+
+func (h httpServeTarget) Serve(l net.Listener) error {
+	if err := h.Server.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+type gRPCServeTarget struct {
+	Addr string
+	*grpc.Server
+}
+
+func (g gRPCServeTarget) Address() string { return g.Addr }
+
+func (g gRPCServeTarget) Shutdown(ctx context.Context) error {
+	signal := make(chan struct{})
+	go func() {
+		defer close(signal)
+
+		g.GracefulStop()
+	}()
+
+	select {
+	case <-ctx.Done():
+		g.Stop()
+		return errors.New("graceful stop failed")
+
+	case <-signal:
+	}
+
+	return nil
+}


### PR DESCRIPTION
Graceful shutdown of gRPC server is not possible with multiplexing of the HTTP and gRPC server on a single port. So make breaking changes to the mux pkg to instead accept and orchestrate multiple serve targets.

Related to https://github.com/odpf/compass/issues/164.